### PR TITLE
Removed duplicate "let mut" in example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ extern crate rouler;
 
 use rouler::Roller;
 
-let mut let mut stat = Roller::new("3d6");
+let mut stat = Roller::new("3d6");
 
 println!("STR: {}", stat.total());
 println!("DEX: {}", stat.reroll());


### PR DESCRIPTION
I've found a duplicate `let mut` in the example code. My rust is rusty, so I checked if it was a valid syntax in play.rust-lang.org, but found it wasn't and proceeded to change and submit this PR.