### PR TITLE
Update pest to 1.0, add arbitrary die sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,7 @@ documentation = "https://docs.rs/rouler/"
 repository = "https://github.com/jarcane/rouler"
 
 [dependencies]
-pest = "0.4.0"
-rand = "0.3.0"
+pest = "1.0"
+pest_derive = "1.0"
+lazy_static = "1.0"
+rand = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rouler"
 description = "A container-like system for generating dice rolls"
 keywords = ["dice", "roller", "RPG", "game", "gaming"]
-version = "0.1.3"
+version = "0.2.0"
 readme = "README.md"
 authors = ["jarcane <jarcane@users.noreply.github.com>"]
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ if att > def {
 ## Current Wishlist
 
 * Arbitrary die sequences, for custom dice: `Roller::new("4d[1, 3, 5, 7]")`
-* Better error handling for parser/syntax errors
 * (Maybe) FromStr implementation for Rollers: `"3d20 * 2".from_str().unwrap()"`
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,4 +83,4 @@ mod parse;
 mod random;
 mod roll;
 
-pub use roll::{Roller, roll_dice};
+pub use roll::{Roller, roll_dice, roll_dice_or_fail, roller_or_fail};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,12 @@
 //! 
 //! ### 0.1.0
 //! * Initial release 
-#[macro_use]
 extern crate pest;
+#[macro_use]
+extern crate pest_derive;
 extern crate rand;
+#[macro_use]
+extern crate lazy_static;
 
 mod parse;
 mod random;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -47,11 +47,13 @@ pub fn compute(expr: Pairs<Rule>) -> i64 {
                 let d = inner.next().unwrap().as_str();
                 assert!(d == "d" || d == "D");
                 // RHS
-                let sides : Vec<u64> = inner.next().unwrap().as_str().trim_matches(|c| c == '[' || c == ']')
-                    .split(",").map(|s| {
-                        s.trim().parse::<u64>().expect("Did not find a number on RHS!")
-                    })
-                    .collect();
+                let mut sides = vec![];
+                while let Some(s) = inner.next() {
+                    // Collect numbers
+                    if s.as_rule() == Rule::number {
+                        sides.push(s.as_str().parse::<u64>().expect("Non-number found on RHS!"));
+                    }
+                }
                 lhs.signum() * roll_custom_dice_raw(lhs.abs(), &sides)
             },
             _ => unreachable!(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -47,15 +47,12 @@ pub fn compute(expr: Pairs<Rule>) -> i64 {
                 let d = inner.next().unwrap().as_str();
                 assert!(d == "d" || d == "D");
                 // RHS
-                let sides : Vec<i64> = inner.next().unwrap().as_str().trim_matches(|c| c == '[' || c == ']')
+                let sides : Vec<u64> = inner.next().unwrap().as_str().trim_matches(|c| c == '[' || c == ']')
                     .split(",").map(|s| {
-                        s.trim().parse::<i64>().expect("Did not find a number on RHS!")
+                        s.trim().parse::<u64>().expect("Did not find a number on RHS!")
                     })
                     .collect();
-                lhs.signum() * match sides.len() {
-                    1 => roll_dice_raw(lhs.abs(), sides[0] as u64),
-                    _ => roll_custom_dice_raw(lhs.abs(), &sides),
-                }
+                lhs.signum() * roll_custom_dice_raw(lhs.abs(), &sides)
             },
             _ => unreachable!(),
         },

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -16,6 +16,7 @@ lazy_static! {
         use self::Assoc::*;
         use self::Rule::*;
 
+        // Order of precedence: "+-" is less than "*/" is less than "dD"
         PrecClimber::new(vec![
             Operator::new(plus, Left) | Operator::new(minus, Left),
             Operator::new(times, Left) | Operator::new(slash, Left),
@@ -27,6 +28,9 @@ lazy_static! {
 #[derive(Parser)]
 #[grammar = "rouler.pest"]
 pub struct RollParser;
+
+// Force recompile when parse changes
+const _GRAMMAR : &'static str = include_str!("rouler.pest");
 
 pub fn compute(expr: Pairs<Rule>) -> i64 {
     PREC_CLIMBER.climb(

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -30,13 +30,13 @@ lazy_static! {
 pub struct RollParser;
 
 // Force recompile when parse changes
-const _GRAMMAR : &'static str = include_str!("rouler.pest");
+const _GRAMMAR : &str = include_str!("rouler.pest");
 
 pub fn compute(expr: Pairs<Rule>) -> i64 {
     PREC_CLIMBER.climb(
         expr,
         |pair: Pair<Rule>| match pair.as_rule() {
-            Rule::number => pair.as_str().parse::<i64>().unwrap().into(),
+            Rule::number => pair.as_str().parse::<i64>().unwrap(),
             Rule::expr => compute(pair.into_inner()),
             Rule::custom_dice => {
                 let mut inner = pair.into_inner();
@@ -48,12 +48,12 @@ pub fn compute(expr: Pairs<Rule>) -> i64 {
                 assert!(d == "d" || d == "D");
                 // RHS
                 let mut sides = vec![];
-                while let Some(s) = inner.next() {
+                for s in inner {
                     // Collect numbers
                     if s.as_rule() == Rule::number {
                         sides.push(s.as_str().parse::<u64>().expect("Non-number found on RHS!"));
                     }
-                }
+                };
                 lhs.signum() * roll_custom_dice_raw(lhs.abs(), &sides)
             },
             _ => unreachable!(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,61 +5,55 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use pest::*;
+use pest::{
+    prec_climber::*,
+    iterators::*,
+};
 use random::*;
 
-impl_rdp! {
-    grammar! {
-        expression = _{
-            { ["("] ~ expression ~ [")"] | number }
-            addition       = { plus  | minus }
-            multiplication = { times | slash }
-            die_roll       = { roll }
-        }
-        number = @{ ["-"]? ~ (["0"] | ['1'..'9'] ~ ['0'..'9']*) }
-        plus   =  { ["+"] }
-        minus  =  { ["-"] }
-        times  =  { ["*"] }
-        slash  =  { ["/"] }
-        roll   =  { ["d"] | ["D"] }
+lazy_static! {
+    static ref PREC_CLIMBER: PrecClimber<Rule> = {
+        use self::Assoc::*;
+        use self::Rule::*;
 
-        whitespace = _{ [" "] }
-    }
+        PrecClimber::new(vec![
+            Operator::new(plus, Left) | Operator::new(minus, Left),
+            Operator::new(times, Left) | Operator::new(slash, Left),
+            Operator::new(roll, Right),
+        ])
+    };
+}
 
-    process! {
-        compute(&self) -> i64 {
-            (&number: number) => number.parse::<i64>().unwrap(),
-            (_: addition, left: compute(), sign, right: compute()) => {
-                match sign.rule {
-                    Rule::plus  => left + right,
-                    Rule::minus => left - right,
-                    _ => unreachable!()
+#[derive(Parser)]
+#[grammar = "rouler.pest"]
+pub struct RollParser;
+
+pub fn compute(expr: Pairs<Rule>) -> i64 {
+    PREC_CLIMBER.climb(
+        expr,
+        |pair: Pair<Rule>| match pair.as_rule() {
+            Rule::number => pair.as_str().parse::<i64>().unwrap(),
+            Rule::expr => compute(pair.into_inner()),
+            _ => unreachable!(),
+        },
+        |lhs: i64, op: Pair<Rule>, rhs: i64| match op.as_rule() {
+            Rule::roll => {
+                if rhs < 1 {
+                    panic!("Sides must be greater than zero")
+                } else {
+                    match lhs.signum() {
+                        0 => panic!("Number of sides must not be zero"),
+                        -1 => -roll_dice_raw(lhs.abs(), rhs as u64),
+                        1 => roll_dice_raw(lhs.abs(), rhs as u64),
+                        _ => unreachable!(),
+                    }
                 }
             },
-            (_: multiplication, left: compute(), sign, right: compute()) => {
-                match sign.rule {
-                    Rule::times => left * right,
-                    Rule::slash => left / right,
-                    _ => unreachable!()
-                }
-            },
-            (_: die_roll, left: compute(), sign, right: compute()) => {
-                match sign.rule {
-                    Rule::roll => {
-                        if right < 1 {
-                            panic!("Sides must be greater than zero");
-                        } else {
-                            match left.signum() {
-                                0  => panic!("Number of sides must not be zero"),
-                                -1 => -roll_dice_raw(left.abs(), right as u64),
-                                1  => roll_dice_raw(left, right as u64),
-                                _  => unreachable!()
-                            }
-                        }
-                    },
-                    _ => unreachable!()
-                }
-            }
+            Rule::plus => lhs + rhs,
+            Rule::minus => lhs - rhs,
+            Rule::times => lhs * rhs,
+            Rule::slash => lhs / rhs,
+            _ => unreachable!(),
         }
-    }
+    )
 }

--- a/src/random.rs
+++ b/src/random.rs
@@ -10,7 +10,7 @@ use rand::{thread_rng, Rng};
 pub fn roll_dice_raw(num: i64, sides: u64) -> i64 {
     let mut rng = thread_rng();
 
-    (0..num.abs()).map(|_| rng.gen_range(1, sides as i64 + 1)).fold(0, |acc, x| acc + x)
+    (0..num.abs()).map(|_| rng.gen_range(1, sides as i64 + 1)).sum()
 }
 
 pub fn roll_custom_dice_raw(num: i64, sides: &[u64]) -> i64 {

--- a/src/random.rs
+++ b/src/random.rs
@@ -12,3 +12,9 @@ pub fn roll_dice_raw(num: i64, sides: u64) -> i64 {
 
     (0..num.abs()).map(|_| rng.gen_range(1, sides as i64 + 1)).fold(0, |acc, x| acc + x)
 }
+
+pub fn roll_custom_dice_raw(num: i64, sides: &[i64]) -> i64 {
+    let mut rng = thread_rng();
+
+    (0..num.abs()).map(|_| rng.choose(sides).unwrap()).fold(0, |acc, x| acc + x)
+}

--- a/src/random.rs
+++ b/src/random.rs
@@ -13,8 +13,8 @@ pub fn roll_dice_raw(num: i64, sides: u64) -> i64 {
     (0..num.abs()).map(|_| rng.gen_range(1, sides as i64 + 1)).fold(0, |acc, x| acc + x)
 }
 
-pub fn roll_custom_dice_raw(num: i64, sides: &[i64]) -> i64 {
+pub fn roll_custom_dice_raw(num: i64, sides: &[u64]) -> i64 {
     let mut rng = thread_rng();
 
-    (0..num.abs()).map(|_| rng.choose(sides).unwrap()).fold(0, |acc, x| acc + x)
+    (0..num.abs()).map(|_| rng.choose(sides).unwrap()).fold(0, |acc, x| acc + *x as i64)
 }

--- a/src/roll.rs
+++ b/src/roll.rs
@@ -28,10 +28,8 @@ use parse::*;
 /// ```
 ///
 pub fn roll_dice(r: &str) -> i64 {
-    let mut parser = Rdp::new(StringInput::new(r));
-    parser.expression();
-
-    parser.compute()
+    let parser = RollParser::parse(Rule::calc, r);
+    compute(parser.expect("Failed to parse roll!"))
 }
 
 /// The `Roller` is the core struct of the library. The basic principle is to provide a reusable

--- a/src/roll.rs
+++ b/src/roll.rs
@@ -42,7 +42,7 @@ pub fn roll_dice(r: &str) -> i64 {
 /// ```
 /// use rouler::roll_dice_or_fail;
 ///
-/// assert!(roll_dice_or_fail("6d6").is_ok())
+/// assert!(roll_dice_or_fail("6d6").is_ok());
 /// assert!(roll_dice_or_fail("food4").is_err())
 /// ```
 pub fn roll_dice_or_fail(r: &str) -> Result<i64, Error<impl RuleType>> {

--- a/src/roll.rs
+++ b/src/roll.rs
@@ -11,7 +11,7 @@ use std::cmp::Ordering;
 use pest::*;
 use parse::*;
 
-/// A simple function for throwaway die rolls that do not need saved as a
+/// A simple function for throwaway die rolls that do not need to be saved as a
 /// `Roller`. Provided for convenience.
 ///
 /// Takes an input of a `&str` containing syntax for a die roll, returns total.
@@ -30,6 +30,45 @@ use parse::*;
 pub fn roll_dice(r: &str) -> i64 {
     let parser = RollParser::parse(Rule::calc, r);
     compute(parser.expect("Failed to parse roll!"))
+}
+
+/// A function for throwaway die rolls that do not need to be saved as a
+/// `Roller`. Provided for convenience.
+///
+/// Takes an input of a `&str` containing syntax for a die roll, returns Ok(total)
+/// if the input parses successfully, otherwise a `ParsingError`.
+///
+/// # Examples
+/// ```
+/// use rouler::roll_dice_or_fail;
+///
+/// assert!(roll_dice_or_fail("6d6").is_ok())
+/// assert!(roll_dice_or_fail("food4").is_err())
+/// ```
+pub fn roll_dice_or_fail(r: &str) -> Result<i64, Error<impl RuleType>> {
+    let parser = RollParser::parse(Rule::calc, r);
+    parser.map(|p| compute(p))
+}
+
+/// A function for safely creating a new `Roller` without panicking.
+///
+/// Takes a `&str` input and if the syntax parses, returns a Roller wrapped by a Result.
+/// Otherwise returns a `ParsingError`.
+///
+/// # Examples
+/// ```
+/// use rouler::roller_or_fail;
+///
+///
+/// ```
+pub fn roller_or_fail<'a>(r: &'a str) -> Result<Roller<'a>, Error<impl RuleType>> {
+    let parser = RollParser::parse(Rule::calc, r);
+    parser.map(|p| {
+        Roller {
+            roll: r,
+            total: compute(p),
+        }
+    })
 }
 
 /// The `Roller` is the core struct of the library. The basic principle is to provide a reusable
@@ -75,7 +114,7 @@ impl<'a> Roller<'a> {
     /// let def = Roller::new("1d20 + 2");
     /// 
     /// if att > def {
-    ///     println!("You struck the monster!");        
+    ///     println!("You struck the monster!");
     /// } else {
     ///     println!("You missed!");
     /// }

--- a/src/roll.rs
+++ b/src/roll.rs
@@ -47,7 +47,7 @@ pub fn roll_dice(r: &str) -> i64 {
 /// ```
 pub fn roll_dice_or_fail(r: &str) -> Result<i64, Error<impl RuleType>> {
     let parser = RollParser::parse(Rule::calc, r);
-    parser.map(|p| compute(p))
+    parser.map(compute)
 }
 
 /// A function for safely creating a new `Roller` without panicking.
@@ -129,7 +129,7 @@ impl<'a> Roller<'a> {
     /// ```
     pub fn new(roll: &'a str) -> Self {
         Roller {
-            roll: roll,
+            roll,
             total: roll_dice(roll),
         }
     }

--- a/src/rouler.pest
+++ b/src/rouler.pest
@@ -1,0 +1,15 @@
+number = @{ "-"? ~ ("0" | '1'..'9' ~ '0'..'9'*) }
+
+op = _{ plus | minus | times | slash | roll }
+  plus = { "+" }
+  minus = { "-" }
+  times = { "*" }
+  slash = { "/" }
+  roll = { "d" | "D" }
+
+expr = { term ~ (op ~ term)* }
+  term = _{ number | "(" ~ expr ~ ")" }
+
+calc = _{ soi ~ expr ~ eoi }
+
+whitespace = _{ " " }

--- a/src/rouler.pest
+++ b/src/rouler.pest
@@ -9,7 +9,7 @@ op = _{ plus | minus | times | slash }
 dice = _{ number ~ (roll ~ number) }
   roll = { "d" | "D" }
 custom_dice = { number ~ roll ~ sides }
-  sides = _{ "[" ~ number ~ (", " ~ number )* ~ "]" }
+  sides = _{ "[" ~ number ~ ("," ~ number )* ~ "]" }
 
 expr = { term ~ (op ~ term)* }
   term = _{ custom_dice | dice | number | "(" ~ expr ~ ")" }

--- a/src/rouler.pest
+++ b/src/rouler.pest
@@ -1,14 +1,16 @@
 number = @{ "-"? ~ ("0" | '1'..'9' ~ '0'..'9'*) }
 
-op = _{ plus | minus | times | slash | roll }
+op = _{ plus | minus | times | slash }
   plus = { "+" }
   minus = { "-" }
   times = { "*" }
   slash = { "/" }
+
+dice = _{ number ~ (roll ~ number) }
   roll = { "d" | "D" }
 
 expr = { term ~ (op ~ term)* }
-  term = _{ number | "(" ~ expr ~ ")" }
+  term = _{ dice | number | "(" ~ expr ~ ")" }
 
 calc = _{ soi ~ expr ~ eoi }
 

--- a/src/rouler.pest
+++ b/src/rouler.pest
@@ -8,9 +8,11 @@ op = _{ plus | minus | times | slash }
 
 dice = _{ number ~ (roll ~ number) }
   roll = { "d" | "D" }
+custom_dice = { number ~ roll ~ sides }
+  sides = _{ "[" ~ number ~ (", " ~ number )* ~ "]" }
 
 expr = { term ~ (op ~ term)* }
-  term = _{ dice | number | "(" ~ expr ~ ")" }
+  term = _{ custom_dice | dice | number | "(" ~ expr ~ ")" }
 
 calc = _{ soi ~ expr ~ eoi }
 

--- a/tests/roller.rs
+++ b/tests/roller.rs
@@ -42,6 +42,13 @@ fn roll_custom_dice_within_range() {
 }
 
 #[test]
+fn custom_dice_spaces_optional() {
+    for _ in 0..100 {
+        assert_range!(2 => roll_dice("2d[1,3,5]") => 10)
+    }
+}
+
+#[test]
 fn negative_dice_negates_roll_value() {
     assert_range!(-18 => Roller::new("-3d6").total() => -3);
 }

--- a/tests/roller.rs
+++ b/tests/roller.rs
@@ -35,6 +35,13 @@ fn reroll_changes_value() {
 }
 
 #[test]
+fn roll_custom_dice_within_range() {
+    for _ in 0..100 {
+        assert_range!(2 => roll_dice("2d[1, 3, 5]") => 10)
+    }
+}
+
+#[test]
 fn negative_dice_negates_roll_value() {
     assert_range!(-18 => Roller::new("-3d6").total() => -3);
 }

--- a/tests/roller.rs
+++ b/tests/roller.rs
@@ -37,14 +37,14 @@ fn reroll_changes_value() {
 #[test]
 fn roll_custom_dice_within_range() {
     for _ in 0..100 {
-        assert_range!(2 => roll_dice("2d[1, 3, 5]") => 10)
+        assert_range!(10 => roll_dice("2d[5, 6, 7]") => 14)
     }
 }
 
 #[test]
 fn custom_dice_spaces_optional() {
     for _ in 0..100 {
-        assert_range!(2 => roll_dice("2d[1,3,5]") => 10)
+        assert_range!(10 => roll_dice("2d[5,6,7]") => 14)
     }
 }
 


### PR DESCRIPTION
Updates pest dependency to 1.0, allowing for use of error handling (see issue #6) and other richer features.

The one major difference between this code and the existing version of `rouler` is that the rolling operator `d|D` may be chained according to the grammar rules.
This kind of behaviour is probably unexpected and it's not obvious to an observer what the result of a string like `"1d4d6"` would be: in this case, I've chosen it to be right-associative so it would parse to `"1d(4d6)"`, but it may make more sense to just remove that chaining functionality from the grammar.