### PR TITLE
WIP: Implement postfix ops for dice (best/worst)

### DIFF
--- a/src/random.rs
+++ b/src/random.rs
@@ -18,3 +18,18 @@ pub fn roll_custom_dice_raw(num: i64, sides: &[u64]) -> i64 {
 
     (0..num.abs()).map(|_| rng.choose(sides).unwrap()).fold(0, |acc, x| acc + *x as i64)
 }
+
+pub fn roll_and_take_dice_raw(num: i64, sides: u64, take: i64) -> i64 {
+    let mut rng = thread_rng();
+    let mut rolls: Vec<_> = (0..num.abs()).map(|_| rng.gen_range(1, sides as i64 + 1)).collect();
+    rolls.sort_unstable();
+
+    if take.is_positive() {
+        rolls.iter().rev().take(take.abs() as usize).sum()
+    } else if take.is_negative() {
+        rolls.iter().take(take.abs() as usize).sum()
+    } else {
+        // Zero is technically correct even if it seems odd.
+        0
+    }
+}

--- a/src/rouler.pest
+++ b/src/rouler.pest
@@ -6,7 +6,13 @@ op = _{ plus | minus | times | slash }
   times = { "*" }
   slash = { "/" }
 
-dice = _{ number ~ (roll ~ number) }
+post = _{ best | worst | adv | dis }
+  best = { "b" }
+  worst = { "w" }
+  adv = { "a" }
+  dis = { "d" }
+
+dice = { number ~ (roll ~ number) ~ (post ~ number?)? }
   roll = { "d" | "D" }
 custom_dice = { number ~ roll ~ sides }
   sides = _{ "[" ~ number ~ ("," ~ number )* ~ "]" }


### PR DESCRIPTION
This is an unpolished (no tests, not implemented for custom dice) proof-of-concept of postfix operators for dice, done by treating dice as their own opaque token in a similar fashion to custom dice, then including the operator in that rule.

Implemented here are "best of", "worst of", and SRD5's "Advantage" and "Disadvantage" (each implemented as a special case of "best" and "worst").